### PR TITLE
GetProgressEnd() does not calculate correctly

### DIFF
--- a/epublibdroid/src/main/java/in/nashapp/epublibdroid/EpubReaderView.java
+++ b/epublibdroid/src/main/java/in/nashapp/epublibdroid/EpubReaderView.java
@@ -664,13 +664,13 @@ public class EpubReaderView extends WebView {
         return this.getHeight() - 50;
     }
     public float GetProgressStart(){ return Progress;}
-    public float GetProgressEnd(){
-            if(GetTotalContentHeight()<=0)
-                return Progress;
-            else if((Progress+(GetPageHeight()/GetTotalContentHeight()))<1)
-                return Progress+(GetPageHeight()/GetTotalContentHeight());
-            else
-                return 1;
+    public float GetProgressEnd() {
+        if (GetTotalContentHeight() <= 0)
+            return Progress;
+        else if ((Progress + (GetPageHeight() / GetTotalContentHeight())) < 1)
+            return Progress + ((float) GetPageHeight() / (float) GetTotalContentHeight());
+        else
+            return 1;
     }
     public int GetChapterNumber(){
         return ChapterNumber;


### PR DESCRIPTION
You must cast `GetPageHeight()` and `GetTotalContentHeight()` to `float` in order for it to work properly.